### PR TITLE
feat(news): integrate AuthorCard into news post layout

### DIFF
--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -31,7 +31,7 @@ export default async function Home() {
 
   return (
     <main className="w-full">
-      <div className="max-w-[1400px] mx-auto px-4 lg:px-6 py-10">
+      <div className="max-w-[1400px] mx-auto px-4 lg:pl-6 lg:pr-1 py-10 w-full">
         <div className="flex flex-col lg:flex-row gap-8 items-start">
           {authorKey && (
             <aside className="w-full lg:w-[260px] flex-shrink-0 lg:sticky lg:top-20 lg:self-start">

--- a/components/AuthorCard.tsx
+++ b/components/AuthorCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import { MapPin, Mail, Github } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,6 +13,29 @@ interface Props {
 
 export default function AuthorCard({ authorKey, className }: Props) {
   const [open, setOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handleClickOutside(event: globalThis.MouseEvent | globalThis.TouchEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("touchstart", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("touchstart", handleClickOutside);
+    };
+  }, [open]);
+
   const author = authors.find((a) => a.key === authorKey);
 
   if (!author) return null;
@@ -45,7 +68,7 @@ export default function AuthorCard({ authorKey, className }: Props) {
           )}
         </div>
 
-        <div className="relative">
+        <div className="relative" ref={dropdownRef}>
           <button
             onClick={() => setOpen(!open)}
             className="px-4 py-1.5 text-sm font-medium rounded bg-white text-black hover:bg-gray-100"

--- a/components/table-of-contents.tsx
+++ b/components/table-of-contents.tsx
@@ -66,9 +66,7 @@ export function TableOfContents({ content, isSticky = false }: TableOfContentsPr
     });
   };
 
-  const containerClasses = `w-full lg:w-64 bg-gray-900 p-4 rounded-lg ${
-    isSticky ? "sticky top-4 self-start" : ""
-  }`;
+  const containerClasses = `w-full bg-gray-900 p-4 rounded-lg ${isSticky ? "sticky top-4 self-start" : ""}`;
 
   return (
     <nav className={containerClasses}>


### PR DESCRIPTION
# Context

This PR addresses **[Issue #6: Enhance Blog Post Rendering with Reusable Author Component](https://github.com/rudra-iitm/openprinting.github.io/issues/6)**.

It integrates the AuthorCard into the news post layout and makes the page fully responsive, consistent with the layout patterns used across the OpenPrinting website. It ensures author information is displayed only when provided in frontmatter and that the content, metadata, and Table of Contents behave correctly across devices.

---

# Description

The task implements a unified responsive layout using Tailwind breakpoints, integrates the AuthorCard and TableOfContents cleanly into the page, and ensures author information is shown only when provided in frontmatter. Mobile users receive a compact AuthorCard with a dropdown that reveals contact details when needed.

---

# Changes in the Codebase

- Integrated AuthorCard and TableOfContents into a single responsive layout using Tailwind utilities  
- Made author visibility conditional based on frontmatter instead of using a fallback  

### **Updated AuthorCard**
- Added a simple dropdown on mobile to show contact details (email, GitHub, location)  
- Improved typography and spacing for better readability  
- Added safe fallback for missing author images  

### **Updated TableOfContents**
- Ensured mobile and desktop placement consistency  
- Refactored layout structure for correctness without duplicating markup  

---

# Additional Information

- Verified layout on multiple screen sizes (mobile → desktop)  
- Confirmed sticky sidebar behavior for desktop  
- Confirmed smooth TOC navigation for all heading levels  
- `yarn lint` and `yarn build` both pass successfully  
