### PR TITLE
feat(posts): display publication date on article pages

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -46,6 +46,16 @@ export default async function PostPage({
             ? frontmatter.title.trim()
             : "Untitled Article";
 
+    let formattedDate = "";
+    if (typeof frontmatter.date === "string" && frontmatter.date.trim() !== "") {
+        const parsedDate = new Date(frontmatter.date);
+        formattedDate = parsedDate.toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+        });
+    }
+
     const readTime =
         typeof frontmatter.readTime === "string" &&
             frontmatter.readTime.trim() !== ""
@@ -68,9 +78,14 @@ export default async function PostPage({
 
                     <section className="w-full lg:flex-1 lg:min-w-0 lg:max-w-[720px]">
                         <div className="mb-6 px-4">
-                            <h1 className="text-3xl xl:text-4xl font-bold text-white leading-tight mb-3">
+                            <h1 className="text-3xl xl:text-4xl font-bold text-white leading-tight mb-2">
                                 {title}
                             </h1>
+                            {formattedDate && (
+                                <div className="text-gray-400 text-sm mb-3">
+                                    {formattedDate}
+                                </div>
+                            )}
                             {readTime && (
                                 <div className="flex items-center gap-2 text-gray-400 text-sm">
                                     <svg


### PR DESCRIPTION
## Feature: Display publication date for blog posts

Closes #4

### Problem

Currently, blog articles on the new site do not display their publication date on the article page.  
This makes it difficult for readers to understand when a post was published and reduces the contextual value of the content.

### Solution

This PR adds support for displaying the publication date of each article by reading the `date` field from the post frontmatter.

Example frontmatter:

```yaml
date: '2023-06-13'
````

The date is formatted into a human-readable format (e.g. `June 13, 2023`) and displayed below the article title.

### Implementation

* Extracted the `date` field from post frontmatter in `app/[slug]/page.tsx`
* Formatted the date using `toLocaleDateString`
* Displayed the formatted date below the article title
* Kept the existing layout and rendering logic unchanged

### Testing

* Verified that posts correctly display their publication date
* Confirmed that `yarn lint` and `yarn build` complete successfully

### Result

Blog article pages now clearly show their publication date, improving readability and providing better context for readers.