### PR TITLE
Mentor's Image Not loading in production due to unconfigured basepath

### DIFF
--- a/app/gsoc/[year]/[project]/page.tsx
+++ b/app/gsoc/[year]/[project]/page.tsx
@@ -193,7 +193,7 @@ export default async function GsocProjectPage({
                         <div key={mentor} className="flex items-center gap-2">
                           {mentorImages[mentor] ? (
                             <Image
-                              src={basePath + mentorImages[mentor]}
+                              src={`${basePath}${mentorImages[mentor]}`}
                               alt={mentor}
                               width={24}
                               height={24}
@@ -365,7 +365,7 @@ export default async function GsocProjectPage({
                     >
                       {mentorImages[m] ? (
                         <Image
-                          src={basePath + mentorImages[m]}
+                          src={`${basePath}${mentorImages[m]}`}
                           alt={m}
                           width={14}
                           height={14}

--- a/components/gsoc-year-client.tsx
+++ b/components/gsoc-year-client.tsx
@@ -183,7 +183,7 @@ export function GsocYearClient({
                             >
                               {mentorImages[mentor] ? (
                                 <Image
-                                  src={basePath + mentorImages[mentor]}
+                                  src={`${basePath}${mentorImages[mentor]}`}
                                   alt={mentor}
                                   width={14}
                                   height={14}
@@ -271,7 +271,7 @@ export function GsocYearClient({
                             >
                               {mentorImages[mentor] ? (
                                 <Image
-                                  src={basePath + mentorImages[mentor]}
+                                  src={`${basePath}${mentorImages[mentor]}`}
                                   alt={mentor}
                                   width={14}
                                   height={14}


### PR DESCRIPTION
Fixes `Mentor's Image Not loading in production due to unconfigured basepath`

<img width="946" height="650" alt="Screenshot 2026-03-12 at 2 08 18 AM" src="https://github.com/user-attachments/assets/85f1a619-9262-4510-9e2f-2171d39558f1" />
