### PR TITLE
Add author avatars to front page news boxes

### DIFF
--- a/components/news-section.tsx
+++ b/components/news-section.tsx
@@ -5,6 +5,7 @@ import { useInView } from "framer-motion"
 import { useRef } from "react"
 import Link from "next/link"
 import { ArrowRight, Calendar, User } from "lucide-react"
+import Image from "next/image"
 
 function formatDate(dateString: string) {
   const date = new Date(dateString)
@@ -18,6 +19,7 @@ function formatDate(dateString: string) {
 type NewsPost = {
   title: string
   author: string
+  authorImage?: string
   date: string
   excerpt: string
   slug: string
@@ -62,7 +64,19 @@ export default function NewsSection({ posts }: { posts: NewsPost[] }) {
 
                 <div className="flex items-center gap-4 text-xs text-muted-foreground mb-4">
                   <span className="flex items-center gap-1.5">
-                    <User className="w-3 h-3" />
+                    {item.authorImage ? (
+                      <div className="rounded-full overflow-hidden w-4 h-4 border border-border/50">
+                        <Image
+                          src={item.authorImage}
+                          alt={item.author}
+                          width={16}
+                          height={16}
+                          className="object-cover w-full h-full"
+                        />
+                      </div>
+                    ) : (
+                      <User className="w-3 h-3" />
+                    )}
                     {item.author}
                   </span>
                   <span className="flex items-center gap-1.5">

--- a/lib/get-latest-posts.ts
+++ b/lib/get-latest-posts.ts
@@ -1,12 +1,14 @@
 import fs from "fs"
 import path from "path"
 import matter from "gray-matter"
+import authors from "@/data/authors"
 
 const postsDirectory = path.join(process.cwd(), "contents/post")
 
 export type PostMeta = {
   title: string
   author: string
+  authorImage?: string
   date: string
   excerpt: string
   slug: string
@@ -23,9 +25,14 @@ export function getLatestPosts(limit = 3): PostMeta[] {
       const fileContents = fs.readFileSync(fullPath, "utf8")
       const { data } = matter(fileContents)
 
+      const authorKey = typeof data.author === "string" ? data.author.trim() : undefined
+      const authorDef = authorKey ? authors.find(a => a.key === authorKey) : undefined
+      const authorImage = authorDef?.image
+
       return {
         title: data.title,
-        author: data.author,
+        author: authorDef ? authorDef.name : data.author,
+        authorImage,
         date: data.date,
         excerpt: data.excerpt,
         slug,


### PR DESCRIPTION
Fixes #49

## Summary
The news cards displayed on the "News and Events" page already include the author's avatar alongside the author name.
However, the news cards shown on the front page only displayed the author name without the avatar.

This PR updates the front page news boxes to also display the author's avatar, making the presentation consistent with the "News and Events" page.

## Changes
- Added support for `authorImage` in the front page news data returned by `getLatestPosts`.
- Updated `NewsSection` to render the author's avatar next to the author name.
- Preserved the existing layout and styling of the news cards.

## Result
Author avatars now appear in the front page news boxes, aligning the UI with the design already used on the News and Events page.
