### PR TITLE
Improve hero banner appearance in light theme

### DIFF
--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -72,7 +72,7 @@ export default function HeroSection() {
             <Button
               asChild
               size="lg"
-              className="bg-white text-black hover:bg-neutral-200 font-medium h-11 px-8 rounded-full text-sm transition-all duration-200 shadow-[0_0_20px_rgba(255,255,255,0.1)]"
+              className="bg-black text-white border border-black hover:bg-neutral-800 dark:bg-white dark:text-black dark:border-white dark:hover:bg-neutral-200 font-medium h-11 px-8 rounded-full text-sm transition-all duration-200 shadow-[0_0_20px_rgba(255,255,255,0.1)]"
             >
               <Link href="/about-us" prefetch={false} className="flex items-center gap-2">
                 Learn More


### PR DESCRIPTION
Fixes #48

## Summary
The hero banner on the main page appeared visually inconsistent in the light theme. This PR improves the appearance of the hero section when the light theme is enabled.

## Changes
- Adjusted banner overlay so the background image appears correctly in light mode
- Improved visibility of the hero background image
- Added spacing above the badge container for better layout balance
- Updated "Learn More" button styling for better contrast in both themes

## Result
The hero banner now integrates better with the light theme while preserving the original appearance in dark mode.

## Before
![before](https://github.com/user-attachments/assets/3a0cbfc5-c15a-4cef-b5aa-4d201f1e54a0)


## After
![after](https://github.com/user-attachments/assets/8ee17a1e-f960-49ec-819a-a3e8bc614c89)
