### PR TITLE
fix(authors): align author bios with source and enhance author links

### DIFF
--- a/components/AuthorCard.tsx
+++ b/components/AuthorCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
-import { MapPin, Mail, Github } from "lucide-react";
+import { MapPin, Mail, Github, Linkedin, Globe, Link2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import authors from "@/data/authors";
 import { siteConfig } from "@/config/site.config";
@@ -48,6 +48,44 @@ export default function AuthorCard({ authorKey, className }: Props) {
     author.image && author.image !== "NA" ? author.image : placeholder;
   const imgSrc = imgRaw.startsWith("/") ? `${basePath}${imgRaw}` : `${basePath}/${imgRaw}`;
 
+  const extraLinks =
+    author.links?.filter((l) => typeof l?.href === "string" && l.href.trim() !== "") ?? [];
+
+  const linkItems: { label: string; href: string; icon: React.ReactNode; external?: boolean }[] = [
+    ...(author.email
+      ? [
+        {
+          label: "Email",
+          href: author.email,
+          icon: <Mail size={14} className="text-muted-foreground" />,
+          external: false,
+        },
+      ]
+      : []),
+    ...(author.github
+      ? [
+        {
+          label: "GitHub",
+          href: author.github,
+          icon: <Github size={14} className="text-muted-foreground" />,
+          external: true,
+        },
+      ]
+      : []),
+    ...extraLinks.map((l) => {
+      const kind = l.kind ?? "other";
+      const icon =
+        kind === "linkedin" ? (
+          <Linkedin size={14} className="text-muted-foreground" />
+        ) : kind === "website" ? (
+          <Globe size={14} className="text-muted-foreground" />
+        ) : (
+          <Link2 size={14} className="text-muted-foreground" />
+        );
+      return { label: l.label, href: l.href, icon, external: true };
+    }),
+  ];
+
   return (
     <>
       <div className="lg:hidden flex items-center gap-3 px-4 py-4">
@@ -66,8 +104,10 @@ export default function AuthorCard({ authorKey, className }: Props) {
           <h2 className="text-base font-semibold text-foreground leading-tight tracking-tight">
             {author.name}
           </h2>
-          {author.role && (
-            <p className="text-[13px] text-muted-foreground mt-0.5">{author.role}</p>
+          {author.bio && (
+            <p className="text-[13px] text-muted-foreground mt-1 leading-snug">
+              {author.bio}
+            </p>
           )}
         </div>
 
@@ -88,27 +128,18 @@ export default function AuthorCard({ authorKey, className }: Props) {
                 </div>
               )}
 
-              {author.email && (
+              {linkItems.map((item) => (
                 <a
-                  href={author.email}
+                  key={`${item.label}-${item.href}`}
+                  href={item.href}
+                  target={item.external ? "_blank" : undefined}
+                  rel={item.external ? "noopener noreferrer" : undefined}
                   className="flex items-center gap-2 px-3 py-2 text-muted-foreground hover:text-foreground hover:bg-accent"
                 >
-                  <Mail size={14} className="text-muted-foreground" />
-                  <span className="text-sm">Email</span>
+                  {item.icon}
+                  <span className="text-sm">{item.label}</span>
                 </a>
-              )}
-
-              {author.github && (
-                <a
-                  href={author.github}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-2 px-3 py-2 text-muted-foreground hover:text-foreground hover:bg-accent"
-                >
-                  <Github size={14} className="text-muted-foreground" />
-                  <span className="text-sm">GitHub</span>
-                </a>
-              )}
+              ))}
             </div>
           )}
         </div>
@@ -142,9 +173,9 @@ export default function AuthorCard({ authorKey, className }: Props) {
             {author.name}
           </h2>
 
-          {author.role && (
-            <p className="text-sm text-muted-foreground mb-5 pl-2">
-              {author.role}
+          {author.bio && (
+            <p className="text-sm text-muted-foreground mb-5 pl-2 leading-snug">
+              {author.bio}
             </p>
           )}
 
@@ -156,27 +187,28 @@ export default function AuthorCard({ authorKey, className }: Props) {
           )}
 
           <div className="flex flex-col items-start pl-2 gap-3">
-            {author.email && (
+            {linkItems.map((item) => (
               <a
-                href={author.email}
+                key={`${item.label}-${item.href}-desktop`}
+                href={item.href}
+                target={item.external ? "_blank" : undefined}
+                rel={item.external ? "noopener noreferrer" : undefined}
                 className="inline-flex items-center gap-3 text-muted-foreground hover:text-foreground transition-colors duration-200"
               >
-                <Mail size={16} />
-                <span className="text-sm">Email</span>
+                {item.label === "Email" ? (
+                  <Mail size={16} />
+                ) : item.label === "GitHub" ? (
+                  <Github size={16} />
+                ) : item.label === "LinkedIn" ? (
+                  <Linkedin size={16} />
+                ) : item.label === "Website" ? (
+                  <Globe size={16} />
+                ) : (
+                  <Link2 size={16} />
+                )}
+                <span className="text-sm">{item.label}</span>
               </a>
-            )}
-
-            {author.github && (
-              <a
-                href={author.github}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-3 text-muted-foreground hover:text-foreground transition-colors duration-200"
-              >
-                <Github size={16} />
-                <span className="text-sm">GitHub</span>
-              </a>
-            )}
+            ))}
           </div>
         </div>
       </div>

--- a/components/AuthorCard.tsx
+++ b/components/AuthorCard.tsx
@@ -8,6 +8,13 @@ import authors from "@/data/authors";
 import { siteConfig } from "@/config/site.config";
 
 const basePath = siteConfig.urls.basePath;
+function MastodonIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M21.327 8.566c0-4.339-2.843-5.61-2.843-5.61-1.433-.658-3.894-.935-6.451-.956h-.063c-2.557.021-5.016.298-6.45.956 0 0-2.843 1.272-2.843 5.61 0 .993-.019 2.181.012 3.441.103 4.243.778 8.425 4.701 9.463 1.809.479 3.362.579 4.612.51 2.268-.126 3.536-.766 3.536-.766l-.072-1.574s-1.619.511-3.338.449c-1.693-.063-3.476-.194-3.752-2.448a4.198 4.198 0 0 1-.037-.575s1.661.406 3.764.502c1.287.059 2.495-.075 3.724-.221 2.354-.28 4.405-1.724 4.663-3.043.405-2.089.372-5.098.372-5.098l-.001-.002zm-3.809 5.447h-2.494V8.818c0-1.143-.48-1.723-1.443-1.723-1.063 0-1.596.688-1.596 2.047v2.964h-2.48V9.142c0-1.359-.534-2.047-1.596-2.047-.962 0-1.443.58-1.443 1.723v5.195H4.972V8.648c0-1.142.291-2.048.875-2.717.601-.67 1.389-1.013 2.368-1.013 1.132 0 1.989.435 2.556 1.305l.551.924.551-.924c.568-.87 1.425-1.305 2.556-1.305.979 0 1.767.344 2.368 1.013.583.669.875 1.575.875 2.717v5.365z" />
+    </svg>
+  )
+}
 
 interface Props {
   authorKey: string;
@@ -79,6 +86,8 @@ export default function AuthorCard({ authorKey, className }: Props) {
           <Linkedin size={14} className="text-muted-foreground" />
         ) : kind === "website" ? (
           <Globe size={14} className="text-muted-foreground" />
+        ) : kind === "mastodon" ? (
+          <MastodonIcon className="w-[14px] h-[14px] text-muted-foreground" />
         ) : (
           <Link2 size={14} className="text-muted-foreground" />
         );
@@ -203,6 +212,8 @@ export default function AuthorCard({ authorKey, className }: Props) {
                   <Linkedin size={16} />
                 ) : item.label === "Website" ? (
                   <Globe size={16} />
+                ) : item.label === "Mastodon" ? (
+                  <MastodonIcon className="w-[16px] h-[16px]" />
                 ) : (
                   <Link2 size={16} />
                 )}
@@ -211,7 +222,7 @@ export default function AuthorCard({ authorKey, className }: Props) {
             ))}
           </div>
         </div>
-      </div>
+      </div >
     </>
   );
 }

--- a/components/OpenPrintingCard.tsx
+++ b/components/OpenPrintingCard.tsx
@@ -1,12 +1,19 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { MapPin, Github, Globe } from "lucide-react";
+import { MapPin, Github, Globe, Linkedin } from "lucide-react";
 import Image from "next/image";
 import { cn } from "@/lib/utils";
 import { siteConfig } from "@/config/site.config";
 
 const basePath = siteConfig.urls.basePath;
+function MastodonIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M21.327 8.566c0-4.339-2.843-5.61-2.843-5.61-1.433-.658-3.894-.935-6.451-.956h-.063c-2.557.021-5.016.298-6.45.956 0 0-2.843 1.272-2.843 5.61 0 .993-.019 2.181.012 3.441.103 4.243.778 8.425 4.701 9.463 1.809.479 3.362.579 4.612.51 2.268-.126 3.536-.766 3.536-.766l-.072-1.574s-1.619.511-3.338.449c-1.693-.063-3.476-.194-3.752-2.448a4.198 4.198 0 0 1-.037-.575s1.661.406 3.764.502c1.287.059 2.495-.075 3.724-.221 2.354-.28 4.405-1.724 4.663-3.043.405-2.089.372-5.098.372-5.098l-.001-.002zm-3.809 5.447h-2.494V8.818c0-1.143-.48-1.723-1.443-1.723-1.063 0-1.596.688-1.596 2.047v2.964h-2.48V9.142c0-1.359-.534-2.047-1.596-2.047-.962 0-1.443.58-1.443 1.723v5.195H4.972V8.648c0-1.142.291-2.048.875-2.717.601-.67 1.389-1.013 2.368-1.013 1.132 0 1.989.435 2.556 1.305l.551.924.551-.924c.568-.87 1.425-1.305 2.556-1.305.979 0 1.767.344 2.368 1.013.583.669.875 1.575.875 2.717v5.365z" />
+    </svg>
+  )
+}
 
 interface Props {
   className?: string;
@@ -71,7 +78,7 @@ export default function OpenPrintingCard({ className }: Props) {
             <div className="absolute right-0 top-full mt-2 w-48 bg-card rounded shadow-xl border border-border py-1 z-50">
               <div className="flex items-center gap-2 px-3 py-2 text-foreground">
                 <MapPin size={16} className="text-muted-foreground" />
-                <span className="text-sm">Linux Foundation</span>
+                <span className="text-sm">The Linux Foundation</span>
               </div>
 
               <a
@@ -90,6 +97,25 @@ export default function OpenPrintingCard({ className }: Props) {
               >
                 <Github size={16} className="text-muted-foreground" />
                 <span className="text-sm">GitHub</span>
+              </a>
+              <a
+                href="https://ubuntu.social/tags/OpenPrinting"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 px-3 py-2 text-foreground hover:bg-muted"
+              >
+                <MastodonIcon className="w-4 h-4 text-muted-foreground" />
+                <span className="text-sm">Mastodon</span>
+              </a>
+
+              <a
+                href="https://www.linkedin.com/company/openprinting/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 px-3 py-2 text-foreground hover:bg-muted"
+              >
+                <Linkedin size={16} className="text-muted-foreground" />
+                <span className="text-sm">LinkedIn</span>
               </a>
             </div>
           )}
@@ -143,6 +169,25 @@ export default function OpenPrintingCard({ className }: Props) {
             >
               <Github size={18} />
               <span className="text-sm">GitHub</span>
+            </a>
+            <a
+              href="https://ubuntu.social/tags/OpenPrinting"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-3 text-muted-foreground hover:text-primary"
+            >
+              <MastodonIcon className="w-[18px] h-[18px]" />
+              <span className="text-sm">Mastodon</span>
+            </a>
+
+            <a
+              href="https://www.linkedin.com/company/openprinting/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-3 text-muted-foreground hover:text-primary"
+            >
+              <Linkedin size={18} />
+              <span className="text-sm">LinkedIn</span>
             </a>
           </div>
         </div>

--- a/data/authors.ts
+++ b/data/authors.ts
@@ -70,7 +70,7 @@ const authors: Author[] = [
     links: [
       {
         label: "LinkedIn",
-        href: "https://linkedin.com/in/dheeraj-yadav-282330154",
+        href: "https://www.linkedin.com/in/dheeraj135/",
         kind: "linkedin",
       },
     ],

--- a/data/authors.ts
+++ b/data/authors.ts
@@ -1,36 +1,60 @@
 export interface Author {
   key: string;
   name: string;
-  role?: string;
+  bio?: string;
   location?: string;
   email?: string;
   github?: string;
+  links?: {
+    label: string;
+    href: string;
+    kind?: "website" | "linkedin" | "mastodon" | "launchpad" | "other";
+  }[];
   image?: string;
 }
-
 
 const authors: Author[] = [
   {
     key: "Till",
     name: "Till Kamppeter",
-    role: "OpenPrinting Project Leader",
+    bio: "OpenPrinting Organization Lead",
     location: "Vienna, Austria",
     email: "mailto:till.kamppeter@gmail.com",
     github: "https://github.com/tillkamppeter",
+    links: [
+      {
+        label: "LinkedIn",
+        href: "https://linkedin.com/in/kamppetertill",
+        kind: "linkedin",
+      },
+      {
+        label: "Mastodon",
+        href: "https://ubuntu.social/@till",
+        kind: "mastodon",
+      },
+      {
+        label: "Launchpad",
+        href: "https://launchpad.net/~till-kamppeter",
+        kind: "launchpad",
+      },
+    ],
     image: "/authors/till-kamppeter.jpg",
   },
   {
     key: "Mike",
     name: "Michael Sweet",
-    role: "Author of CUPS and PAPPL",
+    bio: "Author of CUPS and PAPPL",
     location: "Canada",
     github: "https://github.com/michaelrsweet",
+    links: [
+      { label: "Website", href: "https://www.msweet.org/", kind: "website" },
+    ],
     image: "/authors/michael-sweet.jpg",
   },
   {
     key: "Aveek",
     name: "Aveek Basu",
-    role: "OpenPrinting Program Manager",
+    bio: "OpenPrinting Program Manager",
     location: "Kolkata, India",
     email: "mailto:basu.aveek@gmail.com",
     github: "https://github.com/AveekBasu",
@@ -39,16 +63,23 @@ const authors: Author[] = [
   {
     key: "Dheeraj",
     name: "Dheeraj",
-    role: "Sub Coordinator, Programming Club, IIT Mandi",
+    bio: "Sub Coordinator, Programming Club, IIT Mandi",
     location: "Mandi, 175001, India",
     email: "mailto:dhirajyadav135@gmail.com",
     github: "https://github.com/dheeraj135",
+    links: [
+      {
+        label: "LinkedIn",
+        href: "https://linkedin.com/in/dheeraj-yadav-282330154",
+        kind: "linkedin",
+      },
+    ],
     image: "/authors/dheeraj135.jpg",
   },
   {
     key: "Zdenek",
     name: "Zdenek Dohnal",
-    role: "Member of CUPS Release Managers group, RHEL/CentOS Stream/Fedora CUPS maintainer",
+    bio: "Member of CUPS Release Managers group, RHEL/CentOS Stream/Fedora CUPS maintainer",
     location: "Brno, Czech Republic",
     github: "https://github.com/zdohnal",
     image: "/authors/placeholder.jpg",
@@ -56,10 +87,22 @@ const authors: Author[] = [
   {
     key: "CNihelton",
     name: "Carlos Nihelton",
-    role: "Software Engineer at Canonical's Ubuntu WSL Team",
+    bio: "Software Engineer at Canonical's Ubuntu WSL Team",
     location: "Campinas, Brazil",
     email: "mailto:carlosnsoliveira@gmail.com",
     github: "https://github.com/CarlosNihelton",
+    links: [
+      {
+        label: "LinkedIn",
+        href: "https://linkedin.com/in/carlos-nihelton",
+        kind: "linkedin",
+      },
+      {
+        label: "Launchpad",
+        href: "https://launchpad.net/~cnihelton",
+        kind: "launchpad",
+      },
+    ],
     image: "/authors/cnihelton.jpg",
   },
 ];


### PR DESCRIPTION
Closes #54

This PR updates the blog author box content to align with the original OpenPrinting website.

### Changes
- Updated author bios to exactly match the original source
- Added and verified relevant author links (LinkedIn, Mastodon, Launchpad, Website)
- Updated OpenPrinting card on `/news`:
  - Added Mastodon and LinkedIn links
  - Corrected "The Linux Foundation" text
- Verified avatar mappings for all authors (no image files modified)

### Improvements
- Enhanced AuthorCard to better surface author links (including improved mobile accessibility)
- Replaced the generic link icon used for Mastodon links in AuthorCard & OpenPrinting card with the Mastodon icon (consistent with footer)

### Notes
- Changes are focused and limited to author data and minimal UI enhancement
- No unnecessary refactoring or unrelated modifications

### Validation
- `yarn dev`: verified author rendering on blog pages
- `yarn lint`: no warnings or errors
- `yarn build`: successful

### Preview
Screenshots from multiple blog posts demonstrating updated author boxes and links.
(Attaching screenshot for reference)

<img width="363" height="513" alt="image" src="https://github.com/user-attachments/assets/e939d40f-3652-42c9-a096-633da2fb0038" />
<br/>
<img width="380" height="614" alt="image" src="https://github.com/user-attachments/assets/c9aab459-986a-4cb3-bc2e-36f665c0c4e1" />
<br/>
<img width="335" height="520" alt="image" src="https://github.com/user-attachments/assets/bf0dff3a-cceb-4187-aee5-139f08b2b16d" />
<br/>
<img width="339" height="493" alt="image" src="https://github.com/user-attachments/assets/14db2907-1723-4fd0-be52-f3c570abbd38" />
<br/>
<img width="375" height="551" alt="image" src="https://github.com/user-attachments/assets/bce336cd-14d5-4440-85ea-edd24cd857e3" />
<br/>
<img width="384" height="517" alt="image" src="https://github.com/user-attachments/assets/98fb0599-e936-4f79-9efd-7a8bd5695069" />

