### PR TITLE
Refactor site config and restore full-page navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,10 @@ When reviewing changes in this repo, optimize for:
 
 - `app/`: route handlers and page entry points
 - `components/`: shared UI, Markdown rendering, navigation, search UI
+- `config/`: centralized site, deployment, and repository-specific configuration
 - `contents/`: source content in Markdown
 - `data/`: structured data for authors, GSOC/GSOD pages, summaries
-- `lib/`: shared helpers for content loading, image path handling, search runtime
+- `lib/`: shared helpers for content loading, image path handling, site path/url resolution, search runtime
 - `scripts/search/`: build-time search index generation
 - `public/`: static assets and generated search index output
 
@@ -29,6 +30,7 @@ Treat these as source files:
 - `components/**`
 - `contents/**`
 - `data/**`
+- `config/**`
 - `lib/**`
 - `scripts/**`
 - config files such as `package.json`, `tsconfig.json`, `next.config.ts`, `eslint.config.mjs`
@@ -45,10 +47,30 @@ If a PR changes generated output without changing the inputs that produce it, ca
 ## Architecture Notes
 
 - Static export is enabled in [`next.config.ts`](/Users/rudra/Desktop/workspace/openprinting/openprinting.github.io/next.config.ts). `output: "export"` means features requiring a server runtime are risky by default.
-- Production builds use `basePath` and `assetPrefix` of `/openprinting.github.io`. Absolute links, image paths, and asset references must continue to work under that prefix.
+- Production build path settings come from [`config/site.config.ts`](/Users/rudra/Desktop/workspace/openprinting/openprinting.github.io/config/site.config.ts). `next.config.ts` reads `productionBasePath` and `productionAssetPrefix` from that file, so repository or deployment moves should be handled there instead of inline.
 - Search index generation runs in `prebuild` via `tsx scripts/search/build-index.ts`. Changes affecting content extraction, slugs, URLs, or searchable text often require regenerating `public/search/static-index.json`.
 - A large part of the site is Markdown-driven. Review content pipeline changes for frontmatter assumptions, slug handling, excerpt/title sanitization, and image resolution.
 - This repo uses Yarn as the expected package manager. Flag changes that introduce package-manager drift or inconsistent lockfile/package-manager usage unless the migration is intentional.
+- Shared asset/url helpers now live in [`lib/site.ts`](/Users/rudra/Desktop/workspace/openprinting/openprinting.github.io/lib/site.ts) and [`lib/utils.ts`](/Users/rudra/Desktop/workspace/openprinting/openprinting.github.io/lib/utils.ts). Prefer `withBasePath`, `toAbsoluteSiteUrl`, `getAuthorImageSrc`, and `getImageSrc` over ad hoc path concatenation.
+
+## Portability Rules
+
+- Treat [`config/site.config.ts`](/Users/rudra/Desktop/workspace/openprinting/openprinting.github.io/config/site.config.ts) as the single source of truth for:
+  - GitHub Pages base path and asset prefix
+  - canonical site URL
+  - repository slug and related GitHub links
+  - Giscus repo/category configuration
+  - repo- or deployment-specific external links that are reused across the UI
+- When migrating this project to a new repository or deployment target, update `config/site.config.ts` or its `NEXT_PUBLIC_*` overrides first. Do not scatter new repository names, domains, base paths, or Giscus identifiers across route files or components.
+- For static assets and internal fetches that must honor GitHub Pages subpaths, use the shared helpers instead of `process.env.NODE_ENV` checks in page/component files.
+- If a change introduces a new repo-specific value, add it to the centralized config before using it elsewhere.
+
+## Portability Checklist
+
+- `next.config.ts` still derives `basePath`, `assetPrefix`, and exported env values from the centralized config.
+- Components and routes do not hardcode repository slugs, site URLs, Giscus IDs, or production-only asset prefixes inline.
+- Asset `src` values and fetch URLs continue to work both in local dev and under the configured production base path.
+- Redirects, canonical metadata, and social/organization links still resolve correctly after config changes.
 
 ## Review Focus
 
@@ -62,7 +84,7 @@ If a PR changes generated output without changing the inputs that produce it, ca
 
 - Flag use of features that depend on request-time server execution unless the repo already supports them safely.
 - Be suspicious of changes that assume root-relative assets without considering the production `basePath`.
-- For images and links, prefer helpers already used by the repo such as `getImageSrc`.
+- For images and links, prefer helpers already used by the repo such as `getImageSrc` and `withBasePath`.
 - Check that asset `src` values are valid for both local development and production export. A change that appears to work locally but breaks under the production prefix should be treated as a bug.
 
 ### UI and styling
@@ -121,3 +143,4 @@ If no issues are found, say that explicitly and mention any residual risk, espec
 - Do not overwrite user changes in generated artifacts to "clean up" the diff.
 - If content or search behavior changes, mention whether `public/search/static-index.json` should be regenerated.
 - Keep new code compatible with static export unless the task clearly changes deployment assumptions.
+- When adding repo-specific settings, extend `config/site.config.ts` and consume them via shared helpers instead of new inline constants.

--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -3,20 +3,20 @@ import path from "path";
 import matter from "gray-matter";
 import type { Metadata } from "next";
 import { redirect, notFound } from "next/navigation";
-import Link from "next/link";
+import Link from "@/components/site-link";
 import Image from "next/image";
 import { ArrowRight, ChevronLeft, ChevronRight } from "lucide-react";
 import { MarkdownRenderer } from "@/components/markdown-renderer";
 import { TableOfContents } from "@/components/table-of-contents";
 import GiscusComments from "@/components/giscus-comment";
+import { siteConfig } from "@/config/site.config";
 import AuthorCard from "@/components/AuthorCard";
 import authors from "@/data/authors";
 import { getImageSrc } from "@/lib/utils";
 import { getTeaserImage } from "@/lib/get-latest-posts";
+import { getAuthorImageSrc, toAbsoluteSiteUrl } from "@/lib/site";
 
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
-const siteUrl = "https://openprinting.github.io";
-const defaultOgImageUrl = `${siteUrl}${getImageSrc("/OpenPrintingBox.png")}`;
+const defaultOgImageUrl = toAbsoluteSiteUrl(getImageSrc(siteConfig.assets.boxLogo));
 
 const POSTS_DIR = path.join(process.cwd(), "contents", "post");
 
@@ -76,7 +76,7 @@ export async function generateMetadata({
         return {
             title: "CUPS",
             alternates: {
-                canonical: "https://openprinting.github.io/cups/",
+                canonical: siteConfig.links.cups,
             },
         };
     }
@@ -108,10 +108,10 @@ export async function generateMetadata({
     const imageUrl = resolvedTeaserImage
         ? /^https?:\/\//.test(resolvedTeaserImage)
             ? resolvedTeaserImage
-            : `${siteUrl}${resolvedTeaserImage}`
+            : toAbsoluteSiteUrl(resolvedTeaserImage)
         : defaultOgImageUrl;
     const canonicalPath = resolvedSlug === decodedSlug ? `/${resolvedSlug}` : `/${decodedSlug}`;
-    const canonicalUrl = `${siteUrl}${canonicalPath}`;
+    const canonicalUrl = toAbsoluteSiteUrl(canonicalPath);
 
     return {
         title,
@@ -173,7 +173,7 @@ export default async function PostPage({
     const decodedSlug = decodeURIComponent(slugString);
 
     if (decodedSlug === "cups") {
-        redirect("https://openprinting.github.io/cups/");
+        redirect(siteConfig.links.cups);
     }
 
     const allPosts = await getAllPostsMetadata();
@@ -313,9 +313,7 @@ export default async function PostPage({
                                     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                                         {relatedPosts.map((post) => {
                                             const postAuthor = post.author ? authors.find((a) => a.key === post.author) : null;
-                                            const placeholder = `${basePath}/authors/placeholder.jpg`;
-                                            const imgRaw = postAuthor?.image && postAuthor.image !== "NA" ? postAuthor.image : placeholder;
-                                            const imgSrc = imgRaw.startsWith("/") ? `${basePath}${imgRaw}` : `${basePath}/${imgRaw}`;
+                                            const imgSrc = getAuthorImageSrc(postAuthor?.image);
                                             return (
                                                 <Link
                                                     key={post.slug}

--- a/app/about-us/page.tsx
+++ b/app/about-us/page.tsx
@@ -2,6 +2,8 @@ import fs from "fs/promises"
 import path from "path"
 import matter from "gray-matter"
 import { MarkdownRenderer } from "@/components/markdown-renderer"
+import { siteConfig } from "@/config/site.config"
+import { withBasePath } from "@/lib/site"
 
 const FILE_PATH = path.join(
   process.cwd(),
@@ -9,8 +11,6 @@ const FILE_PATH = path.join(
   "pages",
   "about-us.md"
 )
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
 
 export default async function AboutUsPage() {
   const raw = await fs.readFile(FILE_PATH, "utf8")
@@ -24,7 +24,7 @@ export default async function AboutUsPage() {
       <div className="relative bg-zinc-900 text-white py-24 overflow-hidden">
         <div
           className="absolute inset-0 bg-cover bg-right bg-no-repeat opacity-40"
-          style={{ backgroundImage: `url(${basePath}/rotation_pantone.jpg)`}}
+          style={{ backgroundImage: `url(${withBasePath(siteConfig.assets.heroBackground)})`}}
           aria-hidden
         />
         <div className="absolute inset-0 bg-zinc-900/90" aria-hidden />

--- a/app/achievements/page.tsx
+++ b/app/achievements/page.tsx
@@ -2,6 +2,8 @@ import fs from "fs/promises"
 import path from "path"
 import matter from "gray-matter"
 import { MarkdownRenderer } from "@/components/markdown-renderer"
+import { siteConfig } from "@/config/site.config"
+import { withBasePath } from "@/lib/site"
 
 const FILE_PATH = path.join(
   process.cwd(),
@@ -9,8 +11,6 @@ const FILE_PATH = path.join(
   "pages",
   "achievements.md"
 )
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
 
 export default async function AchievementsPage() {
   const raw = await fs.readFile(FILE_PATH, "utf8")
@@ -24,7 +24,7 @@ export default async function AchievementsPage() {
       <div className="relative bg-zinc-900 text-white py-24 overflow-hidden">
         <div
           className="absolute inset-0 bg-cover bg-right bg-no-repeat opacity-40"
-          style={{ backgroundImage: `url(${basePath}/rotation_pantone.jpg)` }}
+          style={{ backgroundImage: `url(${withBasePath(siteConfig.assets.heroBackground)})` }}
           aria-hidden
         />
         <div className="absolute inset-0 bg-zinc-900/90" aria-hidden />

--- a/app/codeofconduct/page.tsx
+++ b/app/codeofconduct/page.tsx
@@ -2,6 +2,8 @@ import fs from "fs/promises"
 import path from "path"
 import matter from "gray-matter"
 import { MarkdownRenderer } from "@/components/markdown-renderer"
+import { siteConfig } from "@/config/site.config"
+import { withBasePath } from "@/lib/site"
 
 const FILE_PATH = path.join(
   process.cwd(),
@@ -9,8 +11,6 @@ const FILE_PATH = path.join(
   "pages",
   "codeofconduct.md"
 )
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
 
 export default async function CodeOfConductPage() {
   const raw = await fs.readFile(FILE_PATH, "utf8")
@@ -24,7 +24,7 @@ export default async function CodeOfConductPage() {
       <div className="relative bg-zinc-900 text-white py-24 overflow-hidden">
         <div
           className="absolute inset-0 bg-cover bg-right bg-no-repeat opacity-40"
-          style={{ backgroundImage: `url(${basePath}/rotation_pantone.jpg)` }}
+          style={{ backgroundImage: `url(${withBasePath(siteConfig.assets.heroBackground)})` }}
           aria-hidden
         />
         <div className="absolute inset-0 bg-zinc-900/90" aria-hidden />

--- a/app/current/page.tsx
+++ b/app/current/page.tsx
@@ -2,6 +2,8 @@ import fs from "fs/promises"
 import path from "path"
 import matter from "gray-matter"
 import { MarkdownRenderer } from "@/components/markdown-renderer"
+import { siteConfig } from "@/config/site.config"
+import { withBasePath } from "@/lib/site"
 
 const FILE_PATH = path.join(
   process.cwd(),
@@ -9,8 +11,6 @@ const FILE_PATH = path.join(
   "pages",
   "current.md"
 )
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
 
 export default async function CurrentPage() {
   const raw = await fs.readFile(FILE_PATH, "utf8")
@@ -24,7 +24,7 @@ export default async function CurrentPage() {
       <div className="relative bg-zinc-900 text-white py-24 overflow-hidden">
         <div
           className="absolute inset-0 bg-cover bg-right bg-no-repeat opacity-40"
-          style={{ backgroundImage: `url(${basePath}/rotation_pantone.jpg)` }}
+          style={{ backgroundImage: `url(${withBasePath(siteConfig.assets.heroBackground)})` }}
           aria-hidden
         />
         <div className="absolute inset-0 bg-zinc-900/90" aria-hidden />

--- a/app/documentation/page.tsx
+++ b/app/documentation/page.tsx
@@ -1,7 +1,7 @@
 import fs from "fs/promises"
 import path from "path"
 import matter from "gray-matter"
-import Link from "next/link"
+import Link from "@/components/site-link"
 import { MarkdownRenderer } from "@/components/markdown-renderer"
 
 const PAGE_MD = path.join(process.cwd(), "contents", "pages", "documentation.md")

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -2,6 +2,7 @@ import fs from "fs/promises"
 import path from "path"
 import matter from "gray-matter"
 import Image from "next/image"
+import { getImageSrc } from "@/lib/utils"
 
 type FeatureItem = {
   image_path: string
@@ -17,8 +18,6 @@ const FILE_PATH = path.join(
   "pages",
   "downloads.md"
 )
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
 
 export default async function DownloadsPage() {
   const raw = await fs.readFile(FILE_PATH, "utf8")
@@ -43,7 +42,7 @@ export default async function DownloadsPage() {
             <div key={idx}>
               <div className="bg-muted rounded-xl w-full h-[260px] flex items-center justify-center mb-6">
                 <Image
-                  src={`${basePath}/${item.image_path}`}
+                  src={getImageSrc(item.image_path)}
                   alt={item.alt}
                   width={250}
                   height={250}

--- a/app/driverless/page.tsx
+++ b/app/driverless/page.tsx
@@ -3,6 +3,8 @@ import path from "path"
 import matter from "gray-matter"
 import Image from "next/image"
 import { MarkdownRenderer } from "@/components/markdown-renderer"
+import { siteConfig } from "@/config/site.config"
+import { getImageSrc } from "@/lib/utils"
 
 const FILE_PATH = path.join(
   process.cwd(),
@@ -10,8 +12,6 @@ const FILE_PATH = path.join(
   "pages",
   "driverless.md"
 )
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
 
 const driverlessNavItems = [
   { name: "Introduction to Driverless Printing", href: "#introduction" },
@@ -34,7 +34,7 @@ export default async function DriverlessPage() {
             <div className="sticky top-24 bg-card rounded-lg overflow-hidden border border-border">
               <div className="relative w-full h-48">
                 <Image
-                  src={`${basePath}/assets/images/ipp-everywhere.png`}
+                  src={getImageSrc(siteConfig.assets.driverlessHero)}
                   alt="Driverless Printing"
                   fill
                   className="object-cover"

--- a/app/drivers/page.tsx
+++ b/app/drivers/page.tsx
@@ -1,10 +1,11 @@
 "use client"
 
 import { useEffect } from "react"
+import { siteConfig } from "@/config/site.config"
 
 export default function DriversPage() {
   useEffect(() => {
-    window.location.href = "https://openprinting.org/drivers"
+    window.location.href = siteConfig.links.legacyDrivers
   }, [])
   
   return (

--- a/app/gsoc/[year]/[project]/page.tsx
+++ b/app/gsoc/[year]/[project]/page.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/site-link";
 import Image from "next/image";
 import { MarkdownRenderer } from "@/components/markdown-renderer";
 import { TableOfContents } from "@/components/table-of-contents";
@@ -15,6 +15,7 @@ import {
 import { getWorkSummary } from "@/data/gsoc-work-summaries";
 import { getMentorsBySlug } from "@/data/gsoc-mentors";
 import { GsocContributorInlineSocials } from "@/components/gsoc-contributor-socials";
+import { getMentorImageSrc } from "@/lib/site";
 import {
   ArrowLeft,
   User,
@@ -27,8 +28,6 @@ import {
   Shield,
   Lightbulb,
 } from "lucide-react";
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
 
 export async function generateStaticParams() {
   const years = await getGsocYears();
@@ -191,9 +190,9 @@ export default async function GsocProjectPage({
                     <div className="space-y-2">
                       {mentors.map((mentor) => (
                         <div key={mentor} className="flex items-center gap-2">
-                          {mentorImages[mentor] ? (
+                          {getMentorImageSrc(mentorImages[mentor]) ? (
                             <Image
-                              src={`${basePath}${mentorImages[mentor]}`}
+                              src={getMentorImageSrc(mentorImages[mentor])!}
                               alt={mentor}
                               width={24}
                               height={24}
@@ -363,9 +362,9 @@ export default async function GsocProjectPage({
                       key={m}
                       className="inline-flex items-center gap-1 rounded-full border border-purple-500/20 bg-purple-500/10 px-2 py-0.5 text-[11px] font-medium text-purple-700 dark:text-purple-300"
                     >
-                      {mentorImages[m] ? (
+                      {getMentorImageSrc(mentorImages[m]) ? (
                         <Image
-                          src={`${basePath}${mentorImages[m]}`}
+                          src={getMentorImageSrc(mentorImages[m])!}
                           alt={m}
                           width={14}
                           height={14}

--- a/app/gsoc/page.tsx
+++ b/app/gsoc/page.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/site-link";
 import { getGsocYearSummaries } from "@/lib/gsoc";
 import { getContributorsByYear } from "@/data/gsoc-contributors";
 import { ArrowRight, Users, FolderOpen } from "lucide-react";

--- a/app/gsod-2020-students/page.tsx
+++ b/app/gsod-2020-students/page.tsx
@@ -2,9 +2,7 @@ import Image from "next/image"
 import { notFound } from "next/navigation"
 import { GsodHero } from "@/components/gsod-hero"
 import { getGsodContributorBySlug } from "@/data/gsod-contributors"
-
-const basePath =
-  process.env.NODE_ENV === "production" ? "/openprinting.github.io" : ""
+import { withBasePath } from "@/lib/site"
 
 export default function GSoD2020StudentsPage() {
   const contributor = getGsodContributorBySlug("gsod-2020-students")
@@ -30,7 +28,7 @@ export default function GSoD2020StudentsPage() {
             <article className="w-full max-w-sm rounded-xl border border-border bg-card p-8 text-center card-glow">
               <div className="mx-auto mb-6 h-40 w-40 overflow-hidden rounded-full border border-border bg-muted">
                 <Image
-                  src={`${basePath}${contributor.image}`}
+                  src={withBasePath(contributor.image)}
                   alt={contributor.name}
                   width={160}
                   height={160}

--- a/app/gsod/page.tsx
+++ b/app/gsod/page.tsx
@@ -1,7 +1,7 @@
 import fs from "fs/promises"
 import path from "path"
 import matter from "gray-matter"
-import Link from "next/link"
+import Link from "@/components/site-link"
 import { ArrowRight, FolderOpen, Users } from "lucide-react"
 import { GsodHero } from "@/components/gsod-hero"
 

--- a/app/gsod2020/[slug]/page.tsx
+++ b/app/gsod2020/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import fs from "fs/promises"
 import path from "path"
 import matter from "gray-matter"
-import Link from "next/link"
+import Link from "@/components/site-link"
 import { notFound } from "next/navigation"
 import { ArrowLeft } from "lucide-react"
 import { MarkdownRenderer } from "@/components/markdown-renderer"
@@ -73,4 +73,3 @@ export default async function GSoD2020IdeaPage({
     </main>
   )
 }
-

--- a/app/gsod2020/page.tsx
+++ b/app/gsod2020/page.tsx
@@ -1,7 +1,7 @@
 import fs from "fs/promises"
 import path from "path"
 import matter from "gray-matter"
-import Link from "next/link"
+import Link from "@/components/site-link"
 import { ArrowRight, Lightbulb } from "lucide-react"
 import { MarkdownRenderer } from "@/components/markdown-renderer"
 import { GsodHero } from "@/components/gsod-hero"

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -2,6 +2,8 @@ import fs from "fs/promises"
 import path from "path"
 import matter from "gray-matter"
 import { MarkdownRenderer } from "@/components/markdown-renderer"
+import { siteConfig } from "@/config/site.config"
+import { withBasePath } from "@/lib/site"
 
 const FILE_PATH = path.join(
   process.cwd(),
@@ -9,8 +11,6 @@ const FILE_PATH = path.join(
   "pages",
   "history.md"
 )
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
 
 export default async function HistoryPage() {
   const raw = await fs.readFile(FILE_PATH, "utf8")
@@ -24,7 +24,7 @@ export default async function HistoryPage() {
       <div className="relative bg-zinc-900 text-white py-24 overflow-hidden">
         <div
           className="absolute inset-0 bg-cover bg-right bg-no-repeat opacity-40"
-          style={{ backgroundImage: `url(${basePath}/rotation_pantone.jpg)` }}
+          style={{ backgroundImage: `url(${withBasePath(siteConfig.assets.heroBackground)})` }}
           aria-hidden
         />
         <div className="absolute inset-0 bg-zinc-900/90" aria-hidden />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,8 +4,9 @@ import "./globals.css";
 import Navbar from "@/components/navbar";
 import Footer from "@/components/footer";
 import { ThemeProvider } from "@/components/theme-provider";
+import { siteConfig } from "@/config/site.config";
 
-const inter = Inter({ subsets: ["latin"] })
+const inter = Inter({ subsets: ["latin"] });
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -18,8 +19,8 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Openprinting - Openprinting",
-  description: "OpenPrinting is dedicated to providing open-source printing solutions for Linux, Unix, and other operating systems. Explore drivers, tools, and resources to enhance your printing experience.",
+  title: siteConfig.title,
+  description: siteConfig.description,
 };
 
 export default function RootLayout({

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -1,15 +1,15 @@
 import fs from "fs/promises"
 import path from "path"
 import matter from "gray-matter"
-import Link from "next/link"
+import Link from "@/components/site-link"
 import Image from "next/image"
 import OpenPrintingCard from "@/components/OpenPrintingCard"
 import TeaserImage from "@/components/teaser-image"
+import { siteConfig } from "@/config/site.config"
 import authors from "@/data/authors"
 import { getImageSrc } from "@/lib/utils"
 import { getTeaserImage } from "@/lib/get-latest-posts"
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
+import { getAuthorImageSrc } from "@/lib/site"
 
 type Post = {
   slug: string
@@ -46,9 +46,7 @@ export default async function NewsPage() {
 
         let authorImage;
         if (authorDef) {
-          const placeholder = `/authors/placeholder.jpg`;
-          const imgRaw = authorDef.image && authorDef.image !== "NA" ? authorDef.image : placeholder;
-          authorImage = imgRaw.startsWith("/") ? `${basePath}${imgRaw}` : `${basePath}/${imgRaw}`;
+          authorImage = getAuthorImageSrc(authorDef.image);
         }
 
         return {
@@ -102,7 +100,7 @@ export default async function NewsPage() {
                 News and Events
               </h1>
               <a
-                href="http://ftp.pwg.org/pub/pwg/liaison/openprinting/minutes/"
+                href={siteConfig.links.monthlyCallMinutes}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center text-sm font-medium text-blue-400 hover:text-blue-300 transition-colors break-all sm:break-normal"

--- a/app/printers/page.tsx
+++ b/app/printers/page.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useEffect, useMemo } from "react"
 import { Search, ChevronLeft, ChevronRight } from "lucide-react"
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : ""
+import { siteConfig } from "@/config/site.config"
+import { withBasePath } from "@/lib/site"
 
 interface PrinterEntry {
   model: string
@@ -25,7 +25,7 @@ export default function PrintersPage() {
   const [page, setPage] = useState(1)
 
   useEffect(() => {
-    fetch(`${basePath}/assets/json/driverless.json`)
+    fetch(withBasePath("/assets/json/driverless.json"))
       .then((r) => r.json())
       .then((data: PrinterEntry[]) => {
         setPrinters(data.filter((p) => p.model !== "_dummy_"))
@@ -79,7 +79,7 @@ export default function PrintersPage() {
       <div className="relative bg-zinc-900 text-white py-24 overflow-hidden">
         <div
           className="absolute inset-0 bg-cover bg-right bg-no-repeat opacity-40"
-          style={{ backgroundImage: `url('${basePath}/ipp-everywhere.png')` }}
+          style={{ backgroundImage: `url('${withBasePath(siteConfig.assets.ippEverywhere)}')` }}
           aria-hidden
         />
         <div className="absolute inset-0 bg-zinc-900/90" aria-hidden />

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,7 +1,7 @@
 import fs from "fs/promises"
 import path from "path"
 import matter from "gray-matter"
-import Link from "next/link"
+import Link from "@/components/site-link"
 import { MarkdownRenderer } from "@/components/markdown-renderer"
 
 const PAGE_MD = path.join(process.cwd(), "contents", "pages", "projects.md")

--- a/app/upcoming-technologies/page.tsx
+++ b/app/upcoming-technologies/page.tsx
@@ -1,7 +1,7 @@
 import fs from "fs/promises"
 import path from "path"
 import matter from "gray-matter"
-import Link from "next/link"
+import Link from "@/components/site-link"
 
 const PAGE_MD = path.join(
   process.cwd(),

--- a/app/wsl-printer-app/page.tsx
+++ b/app/wsl-printer-app/page.tsx
@@ -3,8 +3,8 @@ import path from "path"
 import matter from "gray-matter"
 import { MarkdownRenderer } from "@/components/markdown-renderer"
 import AuthorCard from "@/components/AuthorCard"
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : ""
+import { siteConfig } from "@/config/site.config"
+import { withBasePath } from "@/lib/site"
 
 const FILE_PATH = path.join(
   process.cwd(),
@@ -27,7 +27,7 @@ export default async function WSLPrinterAppPage() {
       <div className="relative bg-zinc-900 text-white py-24 overflow-hidden">
         <div
           className="absolute inset-0 bg-cover bg-right bg-no-repeat opacity-40"
-          style={{ backgroundImage: `url('${basePath}/rotation_pantone.jpg')` }}
+          style={{ backgroundImage: `url('${withBasePath(siteConfig.assets.heroBackground)}')` }}
           aria-hidden
         />
         <div className="absolute inset-0 bg-zinc-900/90" aria-hidden />

--- a/components/AuthorCard.tsx
+++ b/components/AuthorCard.tsx
@@ -5,8 +5,7 @@ import Image from "next/image";
 import { MapPin, Mail, Github } from "lucide-react";
 import { cn } from "@/lib/utils";
 import authors from "@/data/authors";
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
+import { getAuthorImageSrc } from "@/lib/site";
 
 interface Props {
   authorKey: string;
@@ -42,10 +41,7 @@ export default function AuthorCard({ authorKey, className }: Props) {
 
   if (!author) return null;
 
-  const placeholder = `${basePath}/authors/placeholder.jpg`;
-  const imgRaw =
-    author.image && author.image !== "NA" ? author.image : placeholder;
-  const imgSrc = imgRaw.startsWith("/") ? `${basePath}${imgRaw}` : `${basePath}/${imgRaw}`;
+  const imgSrc = getAuthorImageSrc(author.image);
 
   return (
     <>

--- a/components/OpenPrintingCard.tsx
+++ b/components/OpenPrintingCard.tsx
@@ -3,9 +3,8 @@
 import { useState, useEffect, useRef } from "react";
 import { MapPin, Github, Globe } from "lucide-react";
 import Image from "next/image";
-import { cn } from "@/lib/utils";
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
+import { siteConfig } from "@/config/site.config";
+import { cn, getImageSrc } from "@/lib/utils";
 
 interface Props {
   className?: string;
@@ -42,7 +41,7 @@ export default function OpenPrintingCard({ className }: Props) {
         <div className="flex-1 min-w-0 flex flex-col items-center text-center">
           <div className="mb-3">
             <Image
-              src={`${basePath}/openprinting.png`}
+              src={getImageSrc(siteConfig.assets.logo)}
               alt="OpenPrinting Logo"
               width={64}
               height={64}
@@ -74,7 +73,7 @@ export default function OpenPrintingCard({ className }: Props) {
               </div>
 
               <a
-                href="https://openprinting.github.io/"
+                href={siteConfig.links.home}
                 className="flex items-center gap-2 px-3 py-2 text-foreground hover:bg-muted"
               >
                 <Globe size={16} className="text-muted-foreground" />
@@ -82,7 +81,7 @@ export default function OpenPrintingCard({ className }: Props) {
               </a>
 
               <a
-                href="https://github.com/OpenPrinting"
+                href={siteConfig.links.githubOrg}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center gap-2 px-3 py-2 text-foreground hover:bg-muted"
@@ -104,7 +103,7 @@ export default function OpenPrintingCard({ className }: Props) {
         <div className="flex flex-col items-center text-center">
           <div className="mb-4">
             <Image
-              src={`${basePath}/openprinting.png`}
+              src={getImageSrc(siteConfig.assets.logo)}
               alt="OpenPrinting Logo"
               width={96}
               height={96}
@@ -127,7 +126,7 @@ export default function OpenPrintingCard({ className }: Props) {
 
           <div className="flex flex-col items-start pl-2 gap-3 self-start">
             <a
-              href="https://openprinting.github.io/"
+              href={siteConfig.links.home}
               className="inline-flex items-center gap-3 text-muted-foreground hover:text-primary"
             >
               <Globe size={18} />
@@ -135,7 +134,7 @@ export default function OpenPrintingCard({ className }: Props) {
             </a>
 
             <a
-              href="https://github.com/OpenPrinting"
+              href={siteConfig.links.githubOrg}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-3 text-muted-foreground hover:text-primary"

--- a/components/cta-section.tsx
+++ b/components/cta-section.tsx
@@ -4,7 +4,7 @@ import { motion } from "framer-motion"
 import { useInView } from "framer-motion"
 import { useRef } from "react"
 import { Button } from "@/components/ui/button"
-import Link from "next/link"
+import Link from "@/components/site-link"
 
 export default function CTASection() {
   const ref = useRef(null)

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,7 +1,9 @@
 "use client"
 
-import Link from "next/link"
+import Link from "@/components/site-link"
 import { Github, Linkedin, Rss } from "lucide-react"
+import { siteConfig } from "@/config/site.config"
+import { withBasePath } from "@/lib/site"
 
 function MastodonIcon({ className }: { className?: string }) {
   return (
@@ -20,26 +22,24 @@ const footerLinks = {
     { name: "Documentation", href: "/documentation" },
   ],
   Community: [
-    { name: "GitHub", href: "https://github.com/OpenPrinting" },
+    { name: "GitHub", href: siteConfig.links.githubOrg },
     { name: "Google Summer of Code", href: "/gsoc" },
     { name: "Google Season of Docs", href: "/gsod" },
     { name: "Contribute", href: "/contribute" },
   ],
   Resources: [
-    { name: "CUPS", href: "https://openprinting.github.io/cups/" },
+    { name: "CUPS", href: siteConfig.links.cups },
     { name: "Printer Database", href: "/printers" },
-    { name: "Printer Working Group", href: "https://www.pwg.org/ipp/" },
+    { name: "Printer Working Group", href: siteConfig.links.printerWorkingGroup },
   ],
 }
 
 const socialLinks = [
-  { icon: Github, href: "https://github.com/OpenPrinting", label: "GitHub" },
-  { icon: MastodonIcon, href: "https://ubuntu.social/tags/OpenPrinting", label: "Mastodon" },
-  { icon: Linkedin, href: "https://www.linkedin.com/company/openprinting/posts/", label: "LinkedIn" },
-  { icon: Rss, href: "/feed.xml", label: "RSS Feed" },
+  { icon: Github, href: siteConfig.links.githubOrg, label: "GitHub" },
+  { icon: MastodonIcon, href: siteConfig.links.mastodon, label: "Mastodon" },
+  { icon: Linkedin, href: siteConfig.links.linkedin, label: "LinkedIn" },
+  { icon: Rss, href: siteConfig.links.rssFeed, label: "RSS Feed" },
 ]
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
 
 export default function Footer() {
   return (
@@ -56,7 +56,7 @@ export default function Footer() {
               {socialLinks.map((social) => (
                 <a
                   key={social.label}
-                  href={social.label === "RSS Feed" ? `${basePath}${social.href}` : social.href}
+                  href={social.label === "RSS Feed" ? withBasePath(social.href) : social.href}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="w-9 h-9 rounded-full border border-border bg-background flex items-center justify-center text-muted-foreground hover:text-foreground hover:border-foreground/20 transition-all duration-200"

--- a/components/giscus-comment.tsx
+++ b/components/giscus-comment.tsx
@@ -2,27 +2,29 @@
 
 import Giscus from "@giscus/react";
 import { useTheme } from "next-themes";
+import { siteConfig } from "@/config/site.config";
+import type { Mapping } from "giscus";
 
 export default function GiscusComments() {
-    const { resolvedTheme } = useTheme();
+  const { resolvedTheme } = useTheme();
 
-    return (
-        <div className="mt-10">
-            <Giscus
-                id="comments"
-                repo="rudra-iitm/openprinting.github.io"
-                repoId="R_kgDOOJ9tYQ"
-                category="Blog Comments"
-                categoryId="DIC_kwDOOJ9tYc4C4B5V"
-                mapping="url"
-                term="Welcome to OpenPrinting Blog"
-                reactionsEnabled="1"
-                emitMetadata="0"
-                inputPosition="top"
-                theme={resolvedTheme === "dark" ? "transparent_dark" : "noborder_light"}
-                lang="en"
-                loading="lazy"
-            />
-        </div>
-    );
+  return (
+    <div className="mt-10">
+      <Giscus
+        id="comments"
+        repo={siteConfig.giscus.repo as `${string}/${string}`}
+        repoId={siteConfig.giscus.repoId as `R_${string}`}
+        category={siteConfig.giscus.category}
+        categoryId={siteConfig.giscus.categoryId as `DIC_${string}`}
+        mapping={siteConfig.giscus.mapping as Mapping}
+        term={siteConfig.giscus.term}
+        reactionsEnabled="1"
+        emitMetadata="0"
+        inputPosition="top"
+        theme={resolvedTheme === "dark" ? "transparent_dark" : "noborder_light"}
+        lang="en"
+        loading="lazy"
+      />
+    </div>
+  );
 }

--- a/components/gsoc-org-banner.tsx
+++ b/components/gsoc-org-banner.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { motion } from "framer-motion";
-import Link from "next/link";
+import Link from "@/components/site-link";
 import { Mail, Github, MessageCircle, ExternalLink } from "lucide-react";
+import { siteConfig } from "@/config/site.config";
 
 export function GsocOrgBanner() {
   return (
@@ -39,7 +40,7 @@ export function GsocOrgBanner() {
             LF GSoC Wiki
           </Link>
           <Link
-            href="https://github.com/OpenPrinting"
+            href={siteConfig.links.githubOrg}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted px-3 py-1.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"

--- a/components/gsoc-related-posts.tsx
+++ b/components/gsoc-related-posts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import Link from "@/components/site-link";
 import { useEffect, useMemo, useState } from "react";
 
 type RelatedPostsByYear = Record<string, GsocRelatedPost[]>;

--- a/components/gsoc-year-client.tsx
+++ b/components/gsoc-year-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import Link from "@/components/site-link";
 import Image from "next/image";
 import { motion } from "framer-motion";
 import {
@@ -17,7 +17,7 @@ import type { GsocWorkSummary } from "@/data/gsoc-work-summaries";
 import type { GsocProjectSummary } from "@/lib/gsoc";
 import { getMentorsByYear } from "@/data/gsoc-mentors";
 import { GsocContributorHoverChip } from "@/components/gsoc-contributor-socials";
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
+import { getMentorImageSrc } from "@/lib/site";
 
 type RelatedPost = {
   title: string;
@@ -181,9 +181,9 @@ export function GsocYearClient({
                               key={mentor}
                               className="inline-flex items-center gap-1 rounded-full bg-muted/60 px-2 py-0.5 text-[10px] text-muted-foreground"
                             >
-                              {mentorImages[mentor] ? (
+                              {getMentorImageSrc(mentorImages[mentor]) ? (
                                 <Image
-                                  src={`${basePath}${mentorImages[mentor]}`}
+                                  src={getMentorImageSrc(mentorImages[mentor])!}
                                   alt={mentor}
                                   width={14}
                                   height={14}
@@ -269,9 +269,9 @@ export function GsocYearClient({
                               key={mentor}
                               className="inline-flex items-center gap-1 rounded-full bg-muted/60 px-2 py-0.5 text-[10px] text-muted-foreground"
                             >
-                              {mentorImages[mentor] ? (
+                              {getMentorImageSrc(mentorImages[mentor]) ? (
                                 <Image
-                                  src={`${basePath}${mentorImages[mentor]}`}
+                                  src={getMentorImageSrc(mentorImages[mentor])!}
                                   alt={mentor}
                                   width={14}
                                   height={14}

--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -1,11 +1,11 @@
 "use client"
 
 import { Button } from "@/components/ui/button"
+import { siteConfig } from "@/config/site.config"
 import { motion } from "framer-motion"
-import Link from "next/link"
+import Link from "@/components/site-link"
 import { ArrowRight, ChevronDown } from "lucide-react"
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
+import { withBasePath } from "@/lib/site"
 
 export default function HeroSection() {
   return (
@@ -14,13 +14,13 @@ export default function HeroSection() {
       <div
         className="absolute inset-0 bg-cover bg-[position:80%_0] opacity-100 mix-blend-normal pointer-events-none dark:hidden"
         style={{
-          backgroundImage: `url(${basePath}/rotation_pantone.jpg)`,
+          backgroundImage: `url(${withBasePath(siteConfig.assets.heroBackground)})`,
         }}
       />
       <div
         className="hero-banner-image hidden dark:block"
         style={{
-          backgroundImage: `url(${basePath}/rotation_pantone.jpg)`,
+          backgroundImage: `url(${withBasePath(siteConfig.assets.heroBackground)})`,
         }}
       />
       <div className="hero-glow hidden dark:block" />

--- a/components/info-section.tsx
+++ b/components/info-section.tsx
@@ -4,10 +4,10 @@ import { motion } from "framer-motion"
 import { useInView } from "framer-motion"
 import { useRef } from "react"
 import Image from "next/image"
-import Link from "next/link"
+import Link from "@/components/site-link"
 import { ArrowRight } from "lucide-react"
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
+import { siteConfig } from "@/config/site.config"
+import { getImageSrc } from "@/lib/utils"
 
 type InfoItem = {
   title: string
@@ -26,7 +26,7 @@ export default function InfoSection() {
       title: "About Us",
       description:
         "Learn more about OpenPrinting, how it works, the people involved, and the projects maintained by it",
-      icon: `${basePath}/OpenPrintingBox.png`,
+      icon: getImageSrc(siteConfig.assets.boxLogo),
       href: "/about-us",
       delay: 0.1,
     },
@@ -34,7 +34,7 @@ export default function InfoSection() {
       title: "Contribute",
       description:
         "Know how you can be part of an excellent community and help improve printing experience for millions of users",
-      icon: `${basePath}/contribute.png`,
+      icon: getImageSrc(siteConfig.assets.contribute),
       href: "/contribute",
       delay: 0.2,
     },
@@ -42,8 +42,8 @@ export default function InfoSection() {
       title: "CUPS",
       description:
         "CUPS is the standards-based, open source printing system that is used on Linux® and other operating systems.",
-      icon: `${basePath}/cups.png`,
-      href: "https://openprinting.github.io/cups/",
+      icon: getImageSrc(siteConfig.assets.cups),
+      href: siteConfig.links.cups,
       delay: 0.3,
     },
   ]
@@ -79,7 +79,7 @@ export default function InfoSection() {
               >
                 <div className="mb-5 rounded-lg bg-muted border border-border flex items-center justify-center overflow-hidden p-4 h-40">
                   <Image
-                    src={item.icon || `${basePath}/placeholder.svg`}
+                    src={item.icon || getImageSrc("/placeholder.svg")}
                     alt={item.title}
                     width={160}
                     height={120}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -3,15 +3,14 @@
 import { Search as SearchIcon } from "lucide-react";
 import SearchModal from "@/components/search/SearchModal";
 import { useState, useEffect } from "react"
-import Link from "next/link"
+import Link from "@/components/site-link"
 import Image from "next/image"
 import { Menu, X } from "lucide-react"
 import { motion, AnimatePresence } from "framer-motion"
-import { cn } from "@/lib/utils"
+import { siteConfig } from "@/config/site.config"
 import { Button } from "@/components/ui/button"
 import { ThemeToggle } from "@/components/theme-toggle"
-
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
+import { cn, getImageSrc } from "@/lib/utils"
 
 const navItems = [
   { name: "About Us", href: "/about-us" },
@@ -80,7 +79,7 @@ export default function Navbar() {
           <Link href="/" className="flex items-center gap-3 group">
             <div className="relative w-8 h-8">
               <Image
-                src={`${basePath}/openprinting.png`}
+                src={getImageSrc(siteConfig.assets.logo)}
                 alt="OpenPrinting Logo"
                 width={32}
                 height={32}
@@ -150,7 +149,7 @@ export default function Navbar() {
                 size="sm"
                 className="bg-foreground text-background hover:bg-foreground/90 text-xs font-medium h-8 px-4 rounded-full transition-all duration-200"
               >
-                <Link href="https://github.com/OpenPrinting" target="_blank" rel="noopener noreferrer">
+                <Link href={siteConfig.links.githubOrg} target="_blank" rel="noopener noreferrer">
                   GitHub
                 </Link>
               </Button>
@@ -270,7 +269,7 @@ export default function Navbar() {
                   className="w-full bg-foreground text-background hover:bg-foreground/90 text-xs font-medium rounded-full"
                   onClick={() => setIsOpen(false)}
                 >
-                  <Link href="https://github.com/OpenPrinting" target="_blank" rel="noopener noreferrer">
+                  <Link href={siteConfig.links.githubOrg} target="_blank" rel="noopener noreferrer">
                     GitHub
                   </Link>
                 </Button>

--- a/components/news-card.tsx
+++ b/components/news-card.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import Link from "next/link"
+import Link from "@/components/site-link"
 import { ArrowRight, Calendar, User } from "lucide-react"
 import Image from "next/image"
 import { getImageSrc } from "@/lib/utils"

--- a/components/projects-section.tsx
+++ b/components/projects-section.tsx
@@ -4,11 +4,10 @@ import { motion } from "framer-motion"
 import { useInView } from "framer-motion"
 import { useRef } from "react"
 import Image from "next/image"
-import Link from "next/link"
+import Link from "@/components/site-link"
 import { ArrowRight } from "lucide-react"
-
-const basePath =
-  process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
+import { siteConfig } from "@/config/site.config"
+import { getImageSrc } from "@/lib/utils"
 
 type SoftwareItem = {
   title: string
@@ -37,7 +36,7 @@ export default function ProjectsSection() {
       title: "Driverless Printers",
       description:
         "Most modern printers work 'out of the box' with OpenPrinting software. Browse the thousands of driverless printers.",
-      image: `${basePath}/ipp-everywhere.png`,
+      image: getImageSrc(siteConfig.assets.ippEverywhere),
       href: "/printers",
       delay: 0.1,
     },
@@ -45,16 +44,16 @@ export default function ProjectsSection() {
       title: "Legacy Printers",
       description:
         "The Foomatic printer database lists all of the printers that are supported by free software printer drivers.",
-      image: `${basePath}/printer.png`,
+      image: getImageSrc(siteConfig.assets.printer),
       delay: 0.2,
-      href: "https://openprinting.org/printers",
+      href: siteConfig.links.legacyPrinters,
       isExternal: true,
     },
     {
       title: "Windows?!",
       description:
         "Our Printer Applications revive old printers under current Windows, any model which works under Linux.",
-      image: `${basePath}/wsl-printing-icon.png`,
+      image: getImageSrc(siteConfig.assets.wslPrinting),
       delay: 0.3,
       href: "/wsl-printer-app",
     },
@@ -65,8 +64,8 @@ export default function ProjectsSection() {
       title: "Printer Working Group",
       description:
         "OpenPrinting collaborates with the PWG's Internet Printing Protocol workgroup to support this ubiquitous printing standard.",
-      image: `${basePath}/pwg.png`,
-      href: "https://www.pwg.org/ipp/",
+      image: getImageSrc(siteConfig.assets.pwg),
+      href: siteConfig.links.printerWorkingGroup,
       delay: 0.1,
       isExternal: true,
     },
@@ -74,7 +73,7 @@ export default function ProjectsSection() {
       title: "GSoC - OpenPrinting",
       description:
         "OpenPrinting participates in the GSoC program under its umbrella organization The Linux Foundation.",
-      image: `${basePath}/gsoc.jpeg`,
+      image: getImageSrc(siteConfig.assets.gsoc),
       delay: 0.2,
       href: "/gsoc",
     },
@@ -82,7 +81,7 @@ export default function ProjectsSection() {
       title: "GSoD - OpenPrinting",
       description:
         "OpenPrinting participates in the GSoD program under its umbrella organization The Linux Foundation.",
-      image: `${basePath}/gsod.jpg`,
+      image: getImageSrc(siteConfig.assets.gsod),
       delay: 0.3,
       href: "/gsod",
     },
@@ -129,7 +128,7 @@ export default function ProjectsSection() {
               >
                 <div className="p-4 bg-muted border-b border-border flex items-center justify-center">
                   <Image
-                    src={software.image || `${basePath}/placeholder.svg`}
+                    src={software.image || getImageSrc("/placeholder.svg")}
                     alt={software.title}
                     width={200}
                     height={120}
@@ -189,7 +188,7 @@ export default function ProjectsSection() {
                 >
                   <div className="p-4 bg-muted border-b border-border flex items-center justify-center">
                     <Image
-                      src={project.image || `${basePath}/placeholder.svg`}
+                      src={project.image || getImageSrc("/placeholder.svg")}
                       alt={project.title}
                       width={200}
                       height={120}
@@ -217,7 +216,7 @@ export default function ProjectsSection() {
                 >
                   <div className="p-4 bg-muted border-b border-border flex items-center justify-center">
                     <Image
-                      src={project.image || `${basePath}/placeholder.svg`}
+                      src={project.image || getImageSrc("/placeholder.svg")}
                       alt={project.title}
                       width={200}
                       height={120}

--- a/components/search/SearchModal.tsx
+++ b/components/search/SearchModal.tsx
@@ -5,7 +5,7 @@ import { Search as SearchIcon } from "lucide-react";
 import { searchRuntime } from "@/lib/search/runtime-search";
 import type { SearchRuntimeResult } from "@/lib/search/runtime-search";
 import { getImageSrc } from "@/lib/utils";
-import Link from "next/link";
+import Link from "@/components/site-link";
 import TeaserImage from "@/components/teaser-image";
 
 interface SearchModalProps {

--- a/components/site-link.tsx
+++ b/components/site-link.tsx
@@ -1,0 +1,25 @@
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+
+type SiteLinkProps = Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  "children" | "href"
+> & {
+  children: ReactNode;
+  href: string;
+  prefetch?: boolean;
+};
+
+export default function SiteLink({
+  children,
+  href,
+  prefetch,
+  ...props
+}: SiteLinkProps) {
+  void prefetch;
+
+  return (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+}

--- a/components/site-link.tsx
+++ b/components/site-link.tsx
@@ -1,4 +1,5 @@
 import type { AnchorHTMLAttributes, ReactNode } from "react";
+import { normalizeInternalHref } from "@/lib/site";
 
 type SiteLinkProps = Omit<
   AnchorHTMLAttributes<HTMLAnchorElement>,
@@ -18,7 +19,7 @@ export default function SiteLink({
   void prefetch;
 
   return (
-    <a href={href} {...props}>
+    <a href={normalizeInternalHref(href)} {...props}>
       {children}
     </a>
   );

--- a/components/teaser-image.tsx
+++ b/components/teaser-image.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import Image from "next/image";
+import { siteConfig } from "@/config/site.config";
+import { getImageSrc } from "@/lib/utils";
 
 type TeaserImageProps = {
   src: string;
@@ -9,9 +11,6 @@ type TeaserImageProps = {
   className?: string;
   priority?: boolean;
 };
-
-const basePath =
-  process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
 
 export default function TeaserImage({
   src,
@@ -27,7 +26,7 @@ export default function TeaserImage({
       <div className="absolute inset-0 flex items-center justify-center bg-slate-200/35 dark:bg-slate-900/35">
         <div className="relative h-12 w-12 opacity-20 dark:opacity-25">
           <Image
-            src={`${basePath}/openprinting.png`}
+            src={getImageSrc(siteConfig.assets.logo)}
             alt=""
             fill
             aria-hidden="true"

--- a/config/site.config.ts
+++ b/config/site.config.ts
@@ -1,0 +1,89 @@
+/**
+ * Centralized site, repository, and deployment configuration.
+ * Update these values or the matching NEXT_PUBLIC_* environment variables when
+ * migrating this site to a different GitHub Pages repository, domain, or Giscus setup.
+ */
+
+function normalizeBasePath(value: string): string {
+  if (!value) return "";
+
+  const trimmed = value.replace(/^\/+|\/+$/g, "");
+  return trimmed ? `/${trimmed}` : "";
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+const repositoryOwner =
+  process.env.NEXT_PUBLIC_SITE_REPOSITORY_OWNER ?? "openprinting";
+const repositoryName =
+  process.env.NEXT_PUBLIC_SITE_REPOSITORY_NAME ?? "openprinting.github.io";
+
+const productionBasePath = normalizeBasePath(
+  process.env.NEXT_PUBLIC_SITE_BASE_PATH ?? `/${repositoryName}`,
+);
+
+const siteUrl = trimTrailingSlash(
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://openprinting.github.io",
+);
+
+export const siteConfig = {
+  name: "OpenPrinting",
+  title: "Openprinting - Openprinting",
+  description:
+    "OpenPrinting is dedicated to providing open-source printing solutions for Linux, Unix, and other operating systems. Explore drivers, tools, and resources to enhance your printing experience.",
+  repository: {
+    owner: repositoryOwner,
+    name: repositoryName,
+    slug: `${repositoryOwner}/${repositoryName}`,
+  },
+  deployment: {
+    siteUrl,
+    productionBasePath,
+    productionAssetPrefix: productionBasePath ? `${productionBasePath}/` : "",
+  },
+  giscus: {
+    repo:
+      process.env.NEXT_PUBLIC_GISCUS_REPO ??
+      "rudra-iitm/openprinting.github.io",
+    repoId: process.env.NEXT_PUBLIC_GISCUS_REPO_ID ?? "R_kgDOOJ9tYQ",
+    category:
+      process.env.NEXT_PUBLIC_GISCUS_CATEGORY ?? "Blog Comments",
+    categoryId:
+      process.env.NEXT_PUBLIC_GISCUS_CATEGORY_ID ??
+      "DIC_kwDOOJ9tYc4C4B5V",
+    mapping: process.env.NEXT_PUBLIC_GISCUS_MAPPING ?? "url",
+    term:
+      process.env.NEXT_PUBLIC_GISCUS_TERM ??
+      "Welcome to OpenPrinting Blog",
+  },
+  links: {
+    home: `${siteUrl}/`,
+    cups: `${siteUrl}/cups/`,
+    githubOrg: "https://github.com/OpenPrinting",
+    legacyPrinters: "https://openprinting.org/printers",
+    legacyDrivers: "https://openprinting.org/drivers",
+    printerWorkingGroup: "https://www.pwg.org/ipp/",
+    monthlyCallMinutes:
+      "http://ftp.pwg.org/pub/pwg/liaison/openprinting/minutes/",
+    mastodon: "https://ubuntu.social/tags/OpenPrinting",
+    linkedin: "https://www.linkedin.com/company/openprinting/posts/",
+    rssFeed: "/feed.xml",
+  },
+  assets: {
+    logo: "/openprinting.png",
+    boxLogo: "/OpenPrintingBox.png",
+    contribute: "/contribute.png",
+    cups: "/cups.png",
+    ippEverywhere: "/ipp-everywhere.png",
+    printer: "/printer.png",
+    wslPrinting: "/wsl-printing-icon.png",
+    pwg: "/pwg.png",
+    gsoc: "/gsoc.jpeg",
+    gsod: "/gsod.jpg",
+    heroBackground: "/rotation_pantone.jpg",
+    authorPlaceholder: "/authors/placeholder.jpg",
+    driverlessHero: "/assets/images/ipp-everywhere.png",
+  },
+} as const;

--- a/lib/search/runtime-search.ts
+++ b/lib/search/runtime-search.ts
@@ -1,15 +1,14 @@
 import MiniSearch, { type SearchResult } from "minisearch";
+import { withBasePath } from "@/lib/site";
 import type { SearchDocument } from "./types";
 
 let miniSearch: MiniSearch<SearchDocument> | null = null;
 let isInitialized = false;
 
-const basePath = process.env.NODE_ENV === "production" ? "/openprinting.github.io" : "";
-
 async function initializeSearch(): Promise<MiniSearch<SearchDocument>> {
   if (isInitialized && miniSearch) return miniSearch;
 
-  const response = await fetch(`${basePath}/search/static-index.json`);
+  const response = await fetch(withBasePath("/search/static-index.json"));
   const data = await response.json();
 
   const documents: SearchDocument[] = data.documents;

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -13,6 +13,45 @@ export function withBasePath(path: string): string {
   return `${siteBasePath}${normalizedPath}`;
 }
 
+function hasFileExtension(pathname: string): boolean {
+  const lastSegment = pathname.split("/").filter(Boolean).pop() ?? "";
+  return lastSegment.includes(".");
+}
+
+export function normalizeInternalHref(href: string): string {
+  if (
+    !href ||
+    /^([a-z]+:)?\/\//i.test(href) ||
+    href.startsWith("mailto:") ||
+    href.startsWith("tel:") ||
+    href.startsWith("#")
+  ) {
+    return href;
+  }
+
+  const match = href.match(/^([^?#]*)(\?[^#]*)?(#.*)?$/);
+  const pathname = match?.[1] || href;
+  const search = match?.[2] || "";
+  const hash = match?.[3] || "";
+
+  const normalizedPathname = pathname.startsWith("/")
+    ? pathname
+    : `/${pathname}`;
+
+  const pathWithBase = normalizedPathname.startsWith(`${siteBasePath}/`) ||
+    normalizedPathname === siteBasePath ||
+    !siteBasePath
+    ? normalizedPathname
+    : withBasePath(normalizedPathname);
+
+  const needsTrailingSlash =
+    pathWithBase !== "/" &&
+    !pathWithBase.endsWith("/") &&
+    !hasFileExtension(pathWithBase);
+
+  return `${needsTrailingSlash ? `${pathWithBase}/` : pathWithBase}${search}${hash}`;
+}
+
 export function toAbsoluteSiteUrl(path = ""): string {
   if (/^https?:\/\//.test(path)) return path;
 

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,36 @@
+import { siteConfig } from "@/config/site.config";
+
+export const siteBasePath =
+  process.env.NODE_ENV === "production"
+    ? siteConfig.deployment.productionBasePath
+    : "";
+
+export function withBasePath(path: string): string {
+  if (!path) return siteBasePath;
+  if (/^https?:\/\//.test(path)) return path;
+
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${siteBasePath}${normalizedPath}`;
+}
+
+export function toAbsoluteSiteUrl(path = ""): string {
+  if (/^https?:\/\//.test(path)) return path;
+
+  const normalizedPath = path
+    ? path.startsWith("/")
+      ? path
+      : `/${path}`
+    : "";
+
+  return `${siteConfig.deployment.siteUrl}${normalizedPath}`;
+}
+
+export function getAuthorImageSrc(image?: string): string {
+  const source =
+    image && image !== "NA" ? image : siteConfig.assets.authorPlaceholder;
+  return withBasePath(source);
+}
+
+export function getMentorImageSrc(image?: string): string | undefined {
+  return image ? withBasePath(image) : undefined;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,17 +1,17 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+import { withBasePath } from "@/lib/site";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }
 
 export function getImageSrc(src: string): string {
   if (/^https?:\/\//.test(src)) return src;
 
-  const basePath = process.env.NODE_ENV == "production" ? '/openprinting.github.io' : ""
   const normalizedSrc = src.startsWith("../")
     ? src.replace(/^\.\.\//, "/")
     : src;
 
-  return `${basePath}${normalizedSrc.startsWith("/") ? normalizedSrc : `/${normalizedSrc}`}`;
+  return withBasePath(normalizedSrc);
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,16 +1,21 @@
 import type { NextConfig } from "next";
+import { siteConfig } from "./config/site.config";
 
 const isProd = process.env.NODE_ENV === "production";
+const basePath = isProd ? siteConfig.deployment.productionBasePath : "";
+const assetPrefix = isProd
+  ? siteConfig.deployment.productionAssetPrefix
+  : "";
 
 const nextConfig: NextConfig = {
   /* config options here */
   output: "export",
-  basePath: isProd ? "/openprinting.github.io" : "",
-  assetPrefix: isProd ? "/openprinting.github.io/" : "",
+  basePath,
+  assetPrefix,
   trailingSlash: true,
   images: { unoptimized: true },
   env: {
-    NEXT_PUBLIC_BASE_PATH: isProd ? "/openprinting.github.io" : "",
+    NEXT_PUBLIC_BASE_PATH: basePath,
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@types/react-syntax-highlighter": "^15.5.13",
     "eslint": "^9",
     "eslint-config-next": "15.1.6",
     "postcss": "^8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -610,14 +610,7 @@
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz"
   integrity sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==
 
-"@types/react-syntax-highlighter@^15.5.13":
-  version "15.5.13"
-  resolved "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz"
-  integrity sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react@*", "@types/react@^19":
+"@types/react@^19":
   version "19.2.14"
   resolved "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz"
   integrity sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==


### PR DESCRIPTION
## Summary
- centralize repository, deployment, asset, and Giscus settings in `config/site.config.ts`
- add shared site/path helpers in `lib/site.ts` and reuse them across routes and components to remove duplicated base-path logic
- restore full page reloads for internal navigation via `components/site-link.tsx` instead of client-side Next.js transitions
- remove the unused `@types/react-syntax-highlighter` dev dependency and update `AGENTS.md` with the new config and portability conventions

## Testing
- `yarn lint`
- `yarn build`